### PR TITLE
feat: add Supabase utilities and healthcheck endpoint

### DIFF
--- a/src/app/api/healthcheck/route.ts
+++ b/src/app/api/healthcheck/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from 'next/server';
+import { healthcheck } from '@/lib/supabase/healthcheck';
+
+export async function GET() {
+  try {
+    await healthcheck();
+    return NextResponse.json({ ok: true });
+  } catch {
+    return NextResponse.json({ ok: false }, { status: 500 });
+  }
+}

--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -1,0 +1,9 @@
+import { createClient } from '@supabase/supabase-js';
+
+export const createBrowserClient = () => {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+  const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+  return createClient(supabaseUrl, supabaseKey);
+};
+
+export type BrowserSupabaseClient = ReturnType<typeof createBrowserClient>;

--- a/src/lib/supabase/healthcheck.ts
+++ b/src/lib/supabase/healthcheck.ts
@@ -1,0 +1,14 @@
+'use server';
+
+import { createServerClient } from './server';
+
+export async function healthcheck(): Promise<void> {
+  if (!process.env.NEXT_PUBLIC_SUPABASE_URL || !process.env.SUPABASE_SERVICE_ROLE_KEY) {
+    // If Supabase isn't configured, skip the check.
+    return;
+  }
+
+  const supabase = createServerClient();
+  const { error } = await supabase.rpc('now', undefined, { head: true, get: true });
+  if (error) throw error;
+}

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -1,0 +1,12 @@
+import 'server-only';
+import { createClient } from '@supabase/supabase-js';
+
+export const createServerClient = () => {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY!;
+  return createClient(supabaseUrl, serviceRoleKey, {
+    auth: { persistSession: false },
+  });
+};
+
+export type ServerSupabaseClient = ReturnType<typeof createServerClient>;


### PR DESCRIPTION
## Summary
- add Supabase browser and server clients
- include server-side healthcheck using `select now()`
- expose `/api/healthcheck` route for connectivity checks

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ea3527d048323a2c09382bbb18b87