### PR TITLE
feat: add gated dashboard

### DIFF
--- a/src/app/(app)/dashboard/actions.ts
+++ b/src/app/(app)/dashboard/actions.ts
@@ -1,0 +1,30 @@
+'use server'
+
+import { createClient } from '@supabase/supabase-js'
+
+export type Feature = {
+  id: string
+  label: string
+  route: string
+  tier: 'free' | 'pro'
+  enabled: boolean
+}
+
+export async function getFeatures() {
+  const supabase = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
+  )
+
+  const { data, error } = await supabase
+    .from('features')
+    .select('id,label,route,tier,enabled')
+    .order('label')
+
+  if (error) {
+    console.error('Error fetching features', error)
+    return [] as Feature[]
+  }
+
+  return (data as Feature[]) ?? []
+}

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -1,0 +1,69 @@
+import Link from "next/link"
+import { redirect } from "next/navigation"
+import { SignedIn, SignedOut } from "@clerk/nextjs"
+import { auth } from "@clerk/nextjs/server"
+import { createClient } from "@supabase/supabase-js"
+
+import { getFeatures } from "./actions"
+import { Card, CardHeader, CardTitle, CardFooter } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+
+export default async function DashboardPage() {
+  const { userId } = auth()
+
+  const supabase = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
+  )
+
+  let subscribed = false
+  if (userId) {
+    const { data } = await supabase
+      .from("subscriptions")
+      .select("status")
+      .eq("user_id", userId)
+      .single()
+    subscribed = data?.status === "active"
+  }
+
+  const features = await getFeatures()
+
+  return (
+    <>
+      <SignedOut>{redirect("/sign-in")}</SignedOut>
+      <SignedIn>
+        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          {features.map((feature) => (
+            <Card key={feature.id}>
+              <CardHeader className="flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                  <CardTitle>{feature.label}</CardTitle>
+                  <Badge variant="outline">
+                    {feature.tier === "pro" ? "Pro" : "Free"}
+                  </Badge>
+                </div>
+                <Badge variant={feature.enabled ? "default" : "destructive"}>
+                  {feature.enabled ? "Enabled" : "Disabled"}
+                </Badge>
+              </CardHeader>
+              <CardFooter className="gap-2">
+                <Button
+                  asChild
+                  disabled={!feature.enabled || (feature.tier === "pro" && !subscribed)}
+                >
+                  <Link href={feature.route}>Open</Link>
+                </Button>
+                {feature.tier === "pro" && !subscribed && (
+                  <Button variant="secondary" asChild>
+                    <Link href="/pricing">Unlock Pro</Link>
+                  </Button>
+                )}
+              </CardFooter>
+            </Card>
+          ))}
+        </div>
+      </SignedIn>
+    </>
+  )
+}


### PR DESCRIPTION
## Summary
- add server action to query feature list
- implement dashboard page with auth gating and pro module unlock

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ea3e5ad1c8323bf03db818722efcd