### PR TITLE
feat: add settings pages skeleton

### DIFF
--- a/src/app/(app)/settings/billing/page.tsx
+++ b/src/app/(app)/settings/billing/page.tsx
@@ -1,0 +1,3 @@
+export default function BillingSettingsPage() {
+  return <p>Billing settings coming soon.</p>;
+}

--- a/src/app/(app)/settings/family/page.tsx
+++ b/src/app/(app)/settings/family/page.tsx
@@ -1,0 +1,148 @@
+import { currentUser } from "@clerk/nextjs/server";
+import { revalidatePath } from "next/cache";
+import { supabase } from "@/lib/supabase";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
+
+async function createFamily(formData: FormData) {
+  "use server";
+  const user = await currentUser();
+  if (!user) throw new Error("Unauthorized");
+  const name = formData.get("name")?.toString() || "";
+  await supabase.from("families").insert({ user_id: user.id, name });
+  revalidatePath("/settings/family");
+}
+
+async function updateFamily(formData: FormData) {
+  "use server";
+  const user = await currentUser();
+  if (!user) throw new Error("Unauthorized");
+  const id = formData.get("family_id")?.toString();
+  const name = formData.get("name")?.toString() || "";
+  await supabase.from("families").update({ name }).eq("id", id).eq("user_id", user.id);
+  revalidatePath("/settings/family");
+}
+
+async function addMember(formData: FormData) {
+  "use server";
+  const user = await currentUser();
+  if (!user) throw new Error("Unauthorized");
+  const familyId = formData.get("family_id")?.toString();
+  const displayName = formData.get("display_name")?.toString() || "";
+  const role = formData.get("role")?.toString() || "adult";
+  const { data: fam } = await supabase
+    .from("families")
+    .select("id")
+    .eq("id", familyId)
+    .eq("user_id", user.id)
+    .single();
+  if (!fam) throw new Error("Unauthorized");
+  await supabase
+    .from("family_members")
+    .insert({ family_id: familyId, display_name: displayName, role });
+  revalidatePath("/settings/family");
+}
+
+async function removeMember(formData: FormData) {
+  "use server";
+  const user = await currentUser();
+  if (!user) throw new Error("Unauthorized");
+  const id = formData.get("id")?.toString();
+  const familyId = formData.get("family_id")?.toString();
+  const { data: fam } = await supabase
+    .from("families")
+    .select("id")
+    .eq("id", familyId)
+    .eq("user_id", user.id)
+    .single();
+  if (!fam) throw new Error("Unauthorized");
+  await supabase.from("family_members").delete().eq("id", id).eq("family_id", familyId);
+  revalidatePath("/settings/family");
+}
+
+export default async function FamilySettingsPage() {
+  const user = await currentUser();
+  const { data: family } = await supabase
+    .from("families")
+    .select("id, name")
+    .eq("user_id", user?.id)
+    .maybeSingle();
+
+  type Member = {
+    id: string;
+    display_name: string;
+    role: string;
+  };
+
+  let members: Member[] = [];
+  if (family) {
+    const { data: ms } = await supabase
+      .from("family_members")
+      .select("id, display_name, role")
+      .eq("family_id", family.id);
+    members = ms || [];
+  }
+
+  if (!family) {
+    return (
+      <form action={createFamily} className="space-y-4 max-w-md">
+        <div className="space-y-2">
+          <Label htmlFor="name">Family Name</Label>
+          <Input id="name" name="name" />
+        </div>
+        <Button type="submit">Create</Button>
+      </form>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <form action={updateFamily} className="space-y-2 max-w-md">
+        <input type="hidden" name="family_id" value={family.id} />
+        <Label htmlFor="name">Family Name</Label>
+        <Input id="name" name="name" defaultValue={family.name} />
+        <Button type="submit" className="mt-2">Save</Button>
+      </form>
+
+      <div className="space-y-4">
+        <h2 className="font-semibold">Members</h2>
+        <ul className="space-y-2">
+          {members.map((m) => (
+            <li key={m.id} className="flex items-center gap-2">
+              <span>
+                {m.display_name} ({m.role})
+              </span>
+              <form action={removeMember}>
+                <input type="hidden" name="id" value={m.id} />
+                <input type="hidden" name="family_id" value={family.id} />
+                <Button variant="ghost" size="sm" type="submit">
+                  Remove
+                </Button>
+              </form>
+            </li>
+          ))}
+        </ul>
+        <form action={addMember} className="flex flex-wrap items-end gap-2">
+          <input type="hidden" name="family_id" value={family.id} />
+          <div className="space-y-2">
+            <Label htmlFor="display_name">Name</Label>
+            <Input id="display_name" name="display_name" />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="role">Role</Label>
+            <select
+              id="role"
+              name="role"
+              className="border rounded px-2 py-1 text-sm"
+            >
+              <option value="adult">Adult</option>
+              <option value="child">Child</option>
+            </select>
+          </div>
+          <Button type="submit">Add</Button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/settings/layout.tsx
+++ b/src/app/(app)/settings/layout.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+
+export default function SettingsLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const pathname = usePathname();
+  const segment = pathname.split("/")[2] || "profile";
+
+  return (
+    <div>
+      <Tabs value={segment} className="w-full">
+        <TabsList>
+          <TabsTrigger value="profile" asChild>
+            <Link href="/settings/profile">Profile</Link>
+          </TabsTrigger>
+          <TabsTrigger value="family" asChild>
+            <Link href="/settings/family">Family</Link>
+          </TabsTrigger>
+          <TabsTrigger value="billing" asChild>
+            <Link href="/settings/billing">Billing</Link>
+          </TabsTrigger>
+        </TabsList>
+      </Tabs>
+      <div className="mt-6">{children}</div>
+    </div>
+  );
+}

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function SettingsIndexPage() {
+  redirect("/settings/profile");
+}

--- a/src/app/(app)/settings/profile/page.tsx
+++ b/src/app/(app)/settings/profile/page.tsx
@@ -1,0 +1,53 @@
+import { currentUser } from "@clerk/nextjs/server";
+import { supabase } from "@/lib/supabase";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
+import { revalidatePath } from "next/cache";
+
+async function saveProfile(formData: FormData) {
+  "use server";
+
+  const user = await currentUser();
+  if (!user) throw new Error("Unauthorized");
+
+  const displayName = formData.get("display_name")?.toString() || null;
+
+  await supabase
+    .from("users")
+    .upsert({ id: user.id, display_name: displayName });
+
+  revalidatePath("/settings/profile");
+}
+
+export default async function ProfileSettingsPage() {
+  const user = await currentUser();
+  const { data } = await supabase
+    .from("users")
+    .select("display_name")
+    .eq("id", user?.id)
+    .maybeSingle();
+
+  const email = user?.emailAddresses[0]?.emailAddress || "";
+
+  return (
+    <form action={saveProfile} className="space-y-6 max-w-md">
+      <div className="space-y-2">
+        <Label>Email</Label>
+        <Input value={email} disabled />
+        <p className="text-sm text-muted-foreground">
+          Email is managed by Clerk and cannot be changed here.
+        </p>
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="display_name">Display Name</Label>
+        <Input
+          id="display_name"
+          name="display_name"
+          defaultValue={data?.display_name || ""}
+        />
+      </div>
+      <Button type="submit">Save</Button>
+    </form>
+  );
+}

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,0 +1,6 @@
+import { createClient } from "@supabase/supabase-js";
+
+export const supabase = createClient(
+  process.env.SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!
+);


### PR DESCRIPTION
## Summary
- add settings layout with tabs for profile, family and billing
- implement profile settings with display name save and clerk email note
- add basic family management with members and supabase persistence

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_689ea403d490832382741bb2a1435b47