### PR TITLE
feat: add supabase storage utility and test page

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,14 @@ Notes:
 
 After updating `.env.local`, restart the dev server.
 
+## Supabase Storage
+
+The application expects the following buckets to exist:
+
+- `sleep-sounds`
+- `images`
+- `pdf`
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/src/app/(app)/_internal/storage-test/page.tsx
+++ b/src/app/(app)/_internal/storage-test/page.tsx
@@ -1,0 +1,21 @@
+import { SignedIn } from '@clerk/nextjs'
+import { uploadFile, createSignedUrl } from '@/lib/storage'
+
+export default async function Page() {
+  const bucket = 'temp'
+  const path = `test-${Date.now()}.txt`
+  const content = Buffer.from('storage test')
+
+  await uploadFile(bucket, path, content, 'text/plain')
+  const url = await createSignedUrl(bucket, path)
+
+  return (
+    <SignedIn>
+      <div className="p-4 space-y-2">
+        <p>Uploaded {path}</p>
+        <p>Signed URL: {url}</p>
+      </div>
+    </SignedIn>
+  )
+}
+

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,0 +1,37 @@
+'use server'
+
+import { createClient } from '@supabase/supabase-js'
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!
+const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY!
+
+const supabase = createClient(supabaseUrl, supabaseServiceKey)
+
+export async function uploadFile(
+  bucket: string,
+  path: string,
+  file: Blob | ArrayBuffer | Buffer,
+  contentType?: string
+) {
+  const { data, error } = await supabase.storage.from(bucket).upload(path, file, {
+    contentType,
+    upsert: true,
+  })
+
+  if (error) throw error
+  return data
+}
+
+export async function createSignedUrl(
+  bucket: string,
+  path: string,
+  expiresIn = 60
+) {
+  const { data, error } = await supabase.storage
+    .from(bucket)
+    .createSignedUrl(path, expiresIn)
+
+  if (error) throw error
+  return data.signedUrl
+}
+


### PR DESCRIPTION
## Summary
- add supabase storage utility for uploads and signed URLs
- document expected storage buckets
- create internal storage test page stub guarded by SignedIn

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Geist` fonts from Google)*

------
https://chatgpt.com/codex/tasks/task_e_689ea44152b4832385bc942f1c76e528