### PR TITLE
feat: add conversation starters microservice

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
 # dependencies
-/node_modules
+**/node_modules
 /.pnp
 .pnp.*
 .yarn/*

--- a/app/api/convo/cards/route.ts
+++ b/app/api/convo/cards/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from 'next/server'
+import { supabaseAdmin } from '@/lib/supabase'
+import { AgeBand } from '@/lib/convo/types'
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url)
+  const context = searchParams.get('context') || undefined
+  const ageBand = searchParams.get('ageBand') as AgeBand | null
+  const limit = Number(searchParams.get('limit') || '10')
+
+  let query = supabaseAdmin
+    .from('convo_cards')
+    .select('*')
+    .eq('status', 'published')
+
+  if (context) query = query.contains('tags->context', [context])
+
+  const { data: cards, error } = await query.limit(limit)
+
+  if (error)
+    return NextResponse.json({ error: 'failed' }, { status: 500 })
+
+  if (!cards || cards.length === 0 && context) {
+    const { data: fallback } = await supabaseAdmin
+      .from('convo_cards')
+      .select('*')
+      .eq('status', 'published')
+      .limit(limit)
+    return NextResponse.json(adapt(fallback || [], ageBand))
+  }
+
+  return NextResponse.json(adapt(cards, ageBand))
+}
+
+function adapt(cards: any[], ageBand: AgeBand | null) {
+  return cards.map((c) => ({
+    ...c,
+    prompt_text:
+      ageBand && c.age_variants && c.age_variants[ageBand]
+        ? c.age_variants[ageBand]
+        : c.prompt_text
+  }))
+}

--- a/app/api/convo/decks/[id]/route.ts
+++ b/app/api/convo/decks/[id]/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from 'next/server'
+import { supabaseAdmin } from '@/lib/supabase'
+
+export async function GET(
+  request: Request,
+  { params }: { params: { id: string } }
+) {
+  const { id } = params
+  const { data: deck, error } = await supabaseAdmin
+    .from('convo_decks')
+    .select('id,title,subtitle,hero_image_url')
+    .eq('id', id)
+    .eq('status', 'published')
+    .single()
+  if (error || !deck)
+    return NextResponse.json({ error: 'not found' }, { status: 404 })
+
+  const { data: cardsData } = await supabaseAdmin
+    .from('convo_deck_cards')
+    .select(
+      'position, convo_cards:convo_cards(id,prompt_text,follow_ups,age_variants,type,tags,tone)'
+    )
+    .eq('deck_id', id)
+    .order('position', { ascending: true })
+
+  const cards = (cardsData || []).map((c: any) => c.convo_cards)
+
+  return NextResponse.json({ deck, cards })
+}

--- a/app/api/convo/decks/route.ts
+++ b/app/api/convo/decks/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from 'next/server'
+import { supabaseAdmin } from '@/lib/supabase'
+
+export async function GET() {
+  const { data: decks, error } = await supabaseAdmin
+    .from('convo_decks')
+    .select('id,title,subtitle,hero_image_url')
+    .eq('status', 'published')
+
+  if (error) return NextResponse.json({ error: 'failed' }, { status: 500 })
+
+  const results = await Promise.all(
+    (decks ?? []).map(async (d) => {
+      const { count } = await supabaseAdmin
+        .from('convo_deck_cards')
+        .select('*', { count: 'exact', head: true })
+        .eq('deck_id', d.id)
+      return { ...d, cards_count: count || 0 }
+    })
+  )
+
+  return NextResponse.json(results)
+}

--- a/app/api/convo/interaction/route.ts
+++ b/app/api/convo/interaction/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from 'next/server'
+import { auth } from '@clerk/nextjs/server'
+import { supabaseAdmin } from '@/lib/supabase'
+
+export async function POST(req: Request) {
+  const { userId } = await auth()
+  if (!userId) return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+
+  const { cardId, action, rating } = await req.json()
+
+  const { data: existing } = await supabaseAdmin
+    .from('convo_card_interactions')
+    .select('id')
+    .eq('user_id', userId)
+    .eq('card_id', cardId)
+    .maybeSingle()
+
+  const payload: any = {
+    user_id: userId,
+    card_id: cardId,
+    updated_at: new Date().toISOString()
+  }
+
+  if (action === 'favorite') payload.favorite = true
+  if (action === 'hide') payload.hidden = true
+  if (action === 'rate' && rating) payload.rating = rating
+  if (action === 'used') payload.used_at = new Date().toISOString()
+
+  if (existing) {
+    const { error } = await supabaseAdmin
+      .from('convo_card_interactions')
+      .update(payload)
+      .eq('id', existing.id)
+    if (error) return NextResponse.json({ error: 'failed' }, { status: 500 })
+  } else {
+    const { error } = await supabaseAdmin
+      .from('convo_card_interactions')
+      .insert(payload)
+    if (error) return NextResponse.json({ error: 'failed' }, { status: 500 })
+  }
+
+  return NextResponse.json({ ok: true })
+}

--- a/app/api/convo/recommend/route.ts
+++ b/app/api/convo/recommend/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse } from 'next/server'
+import { auth } from '@clerk/nextjs/server'
+import { supabaseAdmin } from '@/lib/supabase'
+import { AgeBand } from '@/lib/convo/types'
+
+export async function POST(req: Request) {
+  const { userId } = await auth()
+  if (!userId) return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+
+  const { ageBand, context, limit = 5 } = await req.json()
+
+  const { data: cards } = await supabaseAdmin
+    .from('convo_cards')
+    .select('*')
+    .eq('status', 'published')
+
+  const { data: interactions } = await supabaseAdmin
+    .from('convo_card_interactions')
+    .select('card_id, hidden, used_at')
+    .eq('user_id', userId)
+
+  const excluded = new Set(
+    (interactions || [])
+      .filter(
+        (i) =>
+          i.hidden ||
+          (i.used_at && Date.now() - new Date(i.used_at).getTime() < 14 * 24 * 3600 * 1000)
+      )
+      .map((i) => i.card_id)
+  )
+
+  const scored = (cards || [])
+    .filter((c) => !excluded.has(c.id))
+    .map((c) => {
+      let score = 0
+      if (context && c.tags?.context?.includes(context)) score += 0.6
+      if (ageBand && c.age_variants && c.age_variants[ageBand]) score += 0.5
+      return { ...c, score }
+    })
+    .sort((a, b) => b.score - a.score)
+
+  const top = scored.slice(0, 20)
+  for (let i = top.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1))
+    ;[top[i], top[j]] = [top[j], top[i]]
+  }
+
+  const selected = top.slice(0, limit).map((c) => ({
+    ...c,
+    prompt_text:
+      ageBand && c.age_variants && c.age_variants[ageBand]
+        ? c.age_variants[ageBand]
+        : c.prompt_text
+  }))
+
+  return NextResponse.json(selected)
+}

--- a/app/convo/deck/[id]/page.tsx
+++ b/app/convo/deck/[id]/page.tsx
@@ -1,0 +1,43 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import Player from '@/components/convo/Player'
+import { ConvoCard, ConvoDeck } from '@/lib/convo/types'
+import { capture } from '@/lib/posthog'
+
+export default function DeckPage({ params }: { params: { id: string } }) {
+  const [deck, setDeck] = useState<ConvoDeck | null>(null)
+  const [cards, setCards] = useState<ConvoCard[]>([])
+  const [play, setPlay] = useState(false)
+
+  useEffect(() => {
+    capture('convo_deck_open', { id: params.id })
+    fetch(`/api/convo/decks/${params.id}`)
+      .then((r) => r.json())
+      .then((res) => {
+        setDeck(res.deck)
+        setCards(res.cards)
+      })
+  }, [params.id])
+
+  if (play) return <Player initialCards={cards} />
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl">{deck?.title}</h1>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
+        {cards.map((c) => (
+          <div key={c.id} className="border p-2">
+            {c.prompt_text}
+          </div>
+        ))}
+      </div>
+      <button
+        className="px-4 py-2 bg-blue-500 text-white rounded"
+        onClick={() => setPlay(true)}
+      >
+        Play
+      </button>
+    </div>
+  )
+}

--- a/app/convo/page.tsx
+++ b/app/convo/page.tsx
@@ -1,0 +1,49 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import QuickStart from '@/components/convo/QuickStart'
+import DeckCard from '@/components/convo/DeckCard'
+import Player from '@/components/convo/Player'
+import { ConvoCard, ConvoDeck, AgeBand } from '@/lib/convo/types'
+import { capture } from '@/lib/posthog'
+import { useSearchParams } from 'next/navigation'
+
+export default function ConvoHome() {
+  const [decks, setDecks] = useState<(ConvoDeck & { cards_count: number })[]>([])
+  const [cards, setCards] = useState<ConvoCard[]>([])
+  const search = useSearchParams()
+  const context = search.get('context') || undefined
+  const ageBand = search.get('ageBand') as AgeBand | null
+
+  useEffect(() => {
+    capture('convo_view_home')
+    fetch('/api/convo/decks').then((r) => r.json()).then(setDecks)
+  }, [])
+
+  useEffect(() => {
+    if (context !== undefined) {
+      fetch(`/api/convo/cards?context=${context}&ageBand=${ageBand ?? ''}`)
+        .then((r) => r.json())
+        .then(setCards)
+    } else {
+      setCards([])
+    }
+  }, [context, ageBand])
+
+  return (
+    <div className="p-4 space-y-4">
+      <div className="flex gap-2">
+        <QuickStart label="Dinner" context="dinner" />
+        <QuickStart label="Car" context="car" />
+        <QuickStart label="Bedtime" context="bedtime" />
+        <QuickStart label="Anywhere" context="" />
+      </div>
+      <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+        {decks.map((d) => (
+          <DeckCard key={d.id} deck={d} />
+        ))}
+      </div>
+      {cards.length > 0 && <Player initialCards={cards} />}
+    </div>
+  )
+}

--- a/sql/convo/0001_init.sql
+++ b/sql/convo/0001_init.sql
@@ -1,0 +1,78 @@
+create extension if not exists "pgcrypto";
+
+-- CARDS
+create table public.convo_cards (
+  id uuid primary key default gen_random_uuid(),
+  prompt_text text not null,
+  follow_ups jsonb default '[]'::jsonb,
+  age_variants jsonb default '{}'::jsonb,
+  type text check (type in ('question','would_you_rather','story_starter','game','gratitude','emotion_coach','repair')) not null,
+  tags jsonb default '{}'::jsonb,
+  tone text check (tone in ('silly','thoughtful','deep','mindful')),
+  sensitivity_flags jsonb default '[]'::jsonb,
+  status text check (status in ('draft','published','retired')) default 'draft',
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
+);
+
+-- DECKS
+create table public.convo_decks (
+  id uuid primary key default gen_random_uuid(),
+  title text not null,
+  subtitle text,
+  hero_image_url text,
+  tags jsonb default '{}'::jsonb,
+  status text check (status in ('draft','published','retired')) default 'draft',
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
+);
+
+-- DECK <-> CARD mapping
+create table public.convo_deck_cards (
+  deck_id uuid references public.convo_decks(id) on delete cascade,
+  card_id uuid references public.convo_cards(id) on delete cascade,
+  position int,
+  primary key (deck_id, card_id)
+);
+
+-- PER-USER INTERACTIONS
+create table public.convo_card_interactions (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references public.users(id) on delete cascade,
+  card_id uuid not null references public.convo_cards(id) on delete cascade,
+  favorite boolean default false,
+  hidden boolean default false,
+  rating int check (rating between 1 and 5),
+  used_at timestamptz,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
+);
+
+-- BASIC INDEXES
+create index on public.convo_cards ((tags->>'context'));
+create index on public.convo_cards (status);
+create index on public.convo_deck_cards (deck_id, position);
+create index on public.convo_card_interactions (user_id, card_id);
+
+-- RLS
+alter table public.convo_cards enable row level security;
+alter table public.convo_decks enable row level security;
+alter table public.convo_deck_cards enable row level security;
+alter table public.convo_card_interactions enable row level security;
+
+create policy "read_published_cards" on public.convo_cards
+for select using (status = 'published');
+
+create policy "read_published_decks" on public.convo_decks
+for select using (status = 'published');
+
+create policy "read_deck_cards" on public.convo_deck_cards
+for select using (exists (select 1 from public.convo_decks d where d.id = deck_id and d.status='published'));
+
+create policy "own_interactions_select" on public.convo_card_interactions
+for select using (user_id = auth.uid());
+
+create policy "own_interactions_write" on public.convo_card_interactions
+for insert with check (user_id = auth.uid())
+,  update using (user_id = auth.uid())
+,  delete using (user_id = auth.uid());

--- a/sql/convo/seed.json
+++ b/sql/convo/seed.json
@@ -1,0 +1,32 @@
+{
+  "decks": [
+    {"title":"Dinner Starters","subtitle":"Quick conversations at the table","hero_image_url":"/img/dinner.jpg","status":"published"}
+  ],
+  "cards": [
+    {
+      "prompt_text":"What was the funniest part of your day?",
+      "follow_ups":["Who was there?","What made it funny?"],
+      "age_variants":{"4-6":"What made you giggle today?"},
+      "type":"question",
+      "tags":{"context":["dinner"],"mood":"calm","energy":"low"},
+      "tone":"thoughtful",
+      "status":"published"
+    },
+    {
+      "prompt_text":"Would you rather fly like a bird or swim like a dolphin?",
+      "follow_ups":["Why?","When would you use it the most?"],
+      "type":"would_you_rather",
+      "tags":{"context":["car","dinner"],"energy":"med"},
+      "tone":"silly",
+      "status":"published"
+    },
+    {
+      "prompt_text":"Tell a 3-sentence story that starts with \u201cA tiny robot knocked on our door\u2026\u201d",
+      "follow_ups":["Add a twist!","Give it a name."],
+      "type":"story_starter",
+      "tags":{"context":["bedtime"],"mood":"calm"},
+      "tone":"creative",
+      "status":"published"
+    }
+  ]
+}

--- a/src/components/convo/Card.tsx
+++ b/src/components/convo/Card.tsx
@@ -1,0 +1,21 @@
+import { ConvoCard } from '@/lib/convo/types'
+
+interface Props {
+  card: ConvoCard
+  showFollowUps: boolean
+}
+
+export default function Card({ card, showFollowUps }: Props) {
+  return (
+    <div className="p-4 text-center">
+      <p className="text-xl mb-4">{card.prompt_text}</p>
+      {showFollowUps && card.follow_ups.length > 0 && (
+        <ul className="list-disc text-left inline-block">
+          {card.follow_ups.map((f) => (
+            <li key={f}>{f}</li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/src/components/convo/DeckCard.tsx
+++ b/src/components/convo/DeckCard.tsx
@@ -1,0 +1,19 @@
+import Link from 'next/link'
+import { ConvoDeck } from '@/lib/convo/types'
+
+interface Props {
+  deck: ConvoDeck & { cards_count?: number }
+}
+
+export default function DeckCard({ deck }: Props) {
+  return (
+    <Link href={`/convo/deck/${deck.id}`} className="border rounded p-2 block">
+      {deck.hero_image_url && (
+        <img src={deck.hero_image_url} alt="" className="w-full h-32 object-cover rounded" />
+      )}
+      <h3 className="font-semibold mt-2">{deck.title}</h3>
+      {deck.subtitle && <p className="text-sm">{deck.subtitle}</p>}
+      <p className="text-xs mt-1">{deck.cards_count ?? 0} cards</p>
+    </Link>
+  )
+}

--- a/src/components/convo/Player.tsx
+++ b/src/components/convo/Player.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import Card from './Card'
+import { ConvoCard } from '@/lib/convo/types'
+import { capture } from '@/lib/posthog'
+
+interface Props {
+  initialCards: ConvoCard[]
+}
+
+export default function Player({ initialCards }: Props) {
+  const [cards] = useState(initialCards)
+  const [index, setIndex] = useState(0)
+  const [showFollowUps, setShowFollowUps] = useState(false)
+
+  const card = cards[index]
+
+  useEffect(() => {
+    if (card) capture('convo_card_view', { cardId: card.id })
+  }, [card])
+
+  async function interact(action: 'favorite' | 'hide' | 'used') {
+    await fetch('/api/convo/interaction', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ cardId: card.id, action })
+    })
+  }
+
+  function next() {
+    setShowFollowUps(false)
+    setIndex((i) => (i + 1) % cards.length)
+  }
+
+  if (!card) return null
+
+  return (
+    <div className="fixed inset-0 bg-white flex flex-col">
+      <div className="flex-1 flex items-center justify-center">
+        <Card card={card} showFollowUps={showFollowUps} />
+      </div>
+      <div className="p-4 flex justify-center gap-4 text-2xl">
+        <button aria-label="Favorite" onClick={() => { capture('convo_card_favorite', { cardId: card.id }); interact('favorite') }}>★</button>
+        <button aria-label="Hide" onClick={() => { capture('convo_card_hide', { cardId: card.id }); interact('hide'); next() }}>🙈</button>
+        <button aria-label="Next" onClick={() => { capture('convo_card_used', { cardId: card.id }); interact('used'); next() }}>▶</button>
+      </div>
+      {card.follow_ups.length > 0 && (
+        <button
+          className="absolute top-2 right-2 underline"
+          onClick={() => setShowFollowUps((s) => !s)}
+        >
+          {showFollowUps ? 'Hide follow-ups' : 'Show follow-ups'}
+        </button>
+      )}
+    </div>
+  )
+}

--- a/src/components/convo/QuickStart.tsx
+++ b/src/components/convo/QuickStart.tsx
@@ -1,0 +1,29 @@
+'use client'
+
+import { useRouter, useSearchParams } from 'next/navigation'
+import { capture } from '@/lib/posthog'
+
+interface Props {
+  label: string
+  context: string
+}
+
+export default function QuickStart({ label, context }: Props) {
+  const router = useRouter()
+  const search = useSearchParams()
+  return (
+    <button
+      className="px-3 py-2 bg-blue-500 text-white rounded"
+      onClick={() => {
+        capture('convo_quick_start_click', { context })
+        const params = new URLSearchParams()
+        if (context) params.set('context', context)
+        const ageBand = search.get('ageBand')
+        if (ageBand) params.set('ageBand', ageBand)
+        router.replace(`/convo?${params.toString()}`)
+      }}
+    >
+      {label}
+    </button>
+  )
+}

--- a/src/lib/convo/types.ts
+++ b/src/lib/convo/types.ts
@@ -1,0 +1,19 @@
+export type AgeBand = "0-3"|"4-6"|"7-9"|"10-12"|"13+"
+
+export type ConvoCard = {
+  id: string
+  prompt_text: string
+  follow_ups: string[]
+  age_variants?: Record<AgeBand, string>
+  type: "question"|"would_you_rather"|"story_starter"|"game"|"gratitude"|"emotion_coach"|"repair"
+  tags: Record<string, any>
+  tone?: "silly"|"thoughtful"|"deep"|"mindful"
+}
+
+export type ConvoDeck = {
+  id: string
+  title: string
+  subtitle?: string
+  hero_image_url?: string
+  tags?: Record<string, any>
+}

--- a/src/lib/posthog.ts
+++ b/src/lib/posthog.ts
@@ -1,0 +1,6 @@
+export function capture(event: string, properties?: Record<string, any>) {
+  if (process.env.NODE_ENV !== 'production') {
+    console.log('posthog.capture', event, properties)
+  }
+  // stub
+}


### PR DESCRIPTION
## Summary
- add conversation deck and card tables with RLS
- implement convo API routes and recommendation logic
- build minimal UI with quick-start buttons, deck gallery and card player

## Testing
- `pnpm test` *(fails: RPC operation 'get_user_todos' error: { message: 'Function not found' } and other plugin database tests)*


------
https://chatgpt.com/codex/tasks/task_e_68ae74a41da88323a782f70ba7187296